### PR TITLE
Feature/fhg 5269 add tests round 2

### DIFF
--- a/cypress/e2e/laManager/kpiReports/navigationViewReport-laMan.spec.js
+++ b/cypress/e2e/laManager/kpiReports/navigationViewReport-laMan.spec.js
@@ -26,11 +26,22 @@ describe('LA Man - performance data - navigate to view reports page', () => {
 
     })
 
-    it('user can navigate to Find report', () => {
+    it('user can navigate to Connect report via nav bar', () => {
+        const expectedPageUrl = "https://test.manage-family-support-services-and-accounts.education.gov.uk/performance-data/Connect";
+
+        // When I click the Find report option
+        cy.get('[data-testid="nav-connect"]').click();
+
+        // Then the Find report page is displayed
+        cy.checkPageUrl(expectedPageUrl);
+
+    })
+
+    it('user can navigate to Find report via nav bar', () => {
         const expectedPageUrl = "https://test.manage-family-support-services-and-accounts.education.gov.uk/performance-data/Find";
 
         // When I click the Find report option
-        cy.contains('Find support for your family').click();
+        cy.get('[data-testid="nav-find"]').click();
 
         // Then the Find report page is displayed
         cy.checkPageUrl(expectedPageUrl);

--- a/cypress/e2e/laManager/kpiReports/navigationViewReport-laMan.spec.js
+++ b/cypress/e2e/laManager/kpiReports/navigationViewReport-laMan.spec.js
@@ -1,0 +1,39 @@
+describe('LA Man - performance data - navigate to view reports page', () => {
+    beforeEach(() => {
+        // Given I am logged in as LA admin
+        cy.visit('/')
+        cy.integrationLogin('laman')
+        // When I click the view data link
+        cy.contains('View Data').click();
+    })
+
+    it('user can navigate to view reports page', () => {
+        const expectedPageUrl = "https://test.manage-family-support-services-and-accounts.education.gov.uk/performance-data/Connect";
+
+        // Then the Connect report page is displayed
+        cy.checkPageUrl(expectedPageUrl);
+
+    })
+
+    it('user can navigate to back to homepage from view reports page', () => {
+        const expectedPageUrl = "https://test.manage-family-support-services-and-accounts.education.gov.uk/Welcome";
+
+        // When I click the back button
+        cy.clickBackLink();
+
+        // Then I am navigated back to the homepage
+        cy.checkPageUrl(expectedPageUrl);
+
+    })
+
+    it('user can navigate to Find report', () => {
+        const expectedPageUrl = "https://test.manage-family-support-services-and-accounts.education.gov.uk/performance-data/Find";
+
+        // When I click the Find report option
+        cy.contains('Find support for your family').click();
+
+        // Then the Find report page is displayed
+        cy.checkPageUrl(expectedPageUrl);
+
+    })
+});

--- a/cypress/e2e/laManager/kpiReports/viewFindReport-laAdmin-performanceData.spec.js
+++ b/cypress/e2e/laManager/kpiReports/viewFindReport-laAdmin-performanceData.spec.js
@@ -30,11 +30,11 @@ describe('LA Man - performance data - navigate to view reports page', () => {
         const expectedLast7DaysReportMetric =  "Searches in the last 7 days";
 
         // Then the page heading for the Find report is displayed correctly
-        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > h2:nth-child(1)', expectedSubHeading);
+        cy.checkPageHeading('[data-testid="h2-overall"]', expectedSubHeading);
 
         // And the expected table headers are displayed correctly
-        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(2) > thead > tr > th:nth-child(1)', expectedTableHeaders[0]);
-        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(2) > thead > tr > th:nth-child(2)', expectedTableHeaders[1]);
+        cy.checkPageHeading('[data-testid="th-measure-overall"]', expectedTableHeaders[0]);
+        cy.checkPageHeading('[data-testid="th-number-overall"]', expectedTableHeaders[1]);
 
         // And the searches metric is displayed
         cy.checkElementContainsText('[data-testid="searches"]', expectedSearchesReportMetric);
@@ -50,11 +50,11 @@ describe('LA Man - performance data - navigate to view reports page', () => {
         const expected4WeeksReportMetric =  "Total number of searches in the last 4 weeks";
 
         // Then the page heading for the Find report is displayed correctly
-        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > h2.govuk-heading-s.govuk-\\!-margin-top-9.govuk-\\!-margin-bottom-3', expectedSubHeading);
+        cy.checkPageHeading('[data-testid="h2-weekly"]', expectedSubHeading);
 
         // And the expected table headers are displayed correctly
-        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(4) > thead > tr > th.govuk-table__header.govuk-\\!-width-one-half', expectedTableHeaders[0]);
-        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(4) > thead > tr > th:nth-child(2)', expectedTableHeaders[1]);
+        cy.checkPageHeading('[data-testid="th-week-weekly"]', expectedTableHeaders[0]);
+        cy.checkPageHeading('[data-testid="th-number-of-searches-weekly"]', expectedTableHeaders[1]);
 
 
         // And the week 1 searches result exists

--- a/cypress/e2e/laManager/kpiReports/viewFindReport-laAdmin-performanceData.spec.js
+++ b/cypress/e2e/laManager/kpiReports/viewFindReport-laAdmin-performanceData.spec.js
@@ -1,0 +1,49 @@
+describe('LA Man - performance data - navigate to view reports page', () => {
+    beforeEach(() => {
+        // Given I am logged in as DFE admin
+        cy.visit('/')
+        cy.integrationLogin('laman')
+        // And I am on the Performance data for Find support for your family LA Admin page
+        cy.navigateToViewFindReportsPage();
+    })
+
+    it('correct page headings displayed for find report', () => {
+        const expectedPageHeading = "Performance data for Find families to support";
+        const expectedSubtext = "Data about local authority services in the Tower Hamlets Council local authority area.";
+        const expectedResultsHeading = "Overall totals for Tower Hamlets Council";
+
+        // Then the page heading for the Find report is displayed correctly
+        cy.checkPageHeading("h1", expectedPageHeading);
+
+        // And the page subtext is displayed correctly
+        cy.checkPageHeading("p", expectedSubtext);
+
+        // And the results heading is displayed correctly - the xpath could not be helped there are no ids/data test ids
+        cy.checkPageHeading('#results > div > div > div > table > thead > tr > th:nth-child(1) > a', expectedResultsHeading);
+
+    })
+
+    it('user can view total number of searches conducted for services in LA', () => {
+        const expectedPageHeading = "Total number of searches in the last 4 weeks";
+
+        // Then the page heading for the Find report is displayed correctly
+        cy.checkPageHeading("h1", expectedPageHeading);
+
+        // And the page subtext is displayed correctly
+        cy.checkPageHeading("p", expectedSubtext);
+
+        // And the results heading is displayed correctly - the xpath could not be helped there are no ids/data test ids
+        cy.checkPageHeading('#results > div > div > div > table > thead > tr > th:nth-child(1) > a', expectedResultsHeading);
+
+    })
+
+    it('user can view number of searches conducted for services in LA in past 7 days', () => {
+
+
+    })
+
+    it('user can view number of searches conducted for services in LA in past 4 weeks', () => {
+
+
+    })
+});

--- a/cypress/e2e/laManager/kpiReports/viewFindReport-laAdmin-performanceData.spec.js
+++ b/cypress/e2e/laManager/kpiReports/viewFindReport-laAdmin-performanceData.spec.js
@@ -8,42 +8,71 @@ describe('LA Man - performance data - navigate to view reports page', () => {
     })
 
     it('correct page headings displayed for find report', () => {
-        const expectedPageHeading = "Performance data for Find families to support";
+        const expectedPageHeading = "Performance data for Find support for your family";
         const expectedSubtext = "Data about local authority services in the Tower Hamlets Council local authority area.";
-        const expectedResultsHeading = "Overall totals for Tower Hamlets Council";
+        const expectedFilterHeader = "Services performance";
 
         // Then the page heading for the Find report is displayed correctly
         cy.checkPageHeading("h1", expectedPageHeading);
 
         // And the page subtext is displayed correctly
-        cy.checkPageHeading("p", expectedSubtext);
+        cy.checkPageHeading('#main-content > div.govuk-grid-row.govuk-\\!-margin-bottom-8 > div > p', expectedSubtext);
 
-        // And the results heading is displayed correctly - the xpath could not be helped there are no ids/data test ids
-        cy.checkPageHeading('#results > div > div > div > table > thead > tr > th:nth-child(1) > a', expectedResultsHeading);
-
-    })
-
-    it('user can view total number of searches conducted for services in LA', () => {
-        const expectedPageHeading = "Total number of searches in the last 4 weeks";
-
-        // Then the page heading for the Find report is displayed correctly
-        cy.checkPageHeading("h1", expectedPageHeading);
-
-        // And the page subtext is displayed correctly
-        cy.checkPageHeading("p", expectedSubtext);
-
-        // And the results heading is displayed correctly - the xpath could not be helped there are no ids/data test ids
-        cy.checkPageHeading('#results > div > div > div > table > thead > tr > th:nth-child(1) > a', expectedResultsHeading);
+        // And the filter heading is displayed correctly - the xpath could not be helped there are no ids/data test ids
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-one-quarter > h2', expectedFilterHeader);
 
     })
 
     it('user can view number of searches conducted for services in LA in past 7 days', () => {
+        const expectedSubHeading = "Overall totals for Tower Hamlets Council";
+        let expectedTableHeaders = ["Measure", "Number"];
+        const expectedSearchesReportMetric =  "Searches";
+        const expectedLast7DaysReportMetric =  "Searches in the last 7 days";
 
+        // Then the page heading for the Find report is displayed correctly
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > h2:nth-child(1)', expectedSubHeading);
+
+        // And the expected table headers are displayed correctly
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(2) > thead > tr > th:nth-child(1)', expectedTableHeaders[0]);
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(2) > thead > tr > th:nth-child(2)', expectedTableHeaders[1]);
+
+        // And the searches metric is displayed
+        cy.checkElementContainsText('[data-testid="searches"]', expectedSearchesReportMetric);
+
+        // And the past 7 days searches metric is displayed
+        cy.checkElementContainsText('[data-testid="recent-searches"]', expectedLast7DaysReportMetric);
 
     })
 
-    it('user can view number of searches conducted for services in LA in past 4 weeks', () => {
+    it('user can view total number of searches conducted for services in LA', () => {
+        const expectedSubHeading = "Searches in the last 4 weeks";
+        let expectedTableHeaders = ["Week", "Number of searches"];
+        const expected4WeeksReportMetric =  "Total number of searches in the last 4 weeks";
 
+        // Then the page heading for the Find report is displayed correctly
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > h2.govuk-heading-s.govuk-\\!-margin-top-9.govuk-\\!-margin-bottom-3', expectedSubHeading);
+
+        // And the expected table headers are displayed correctly
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(4) > thead > tr > th.govuk-table__header.govuk-\\!-width-one-half', expectedTableHeaders[0]);
+        cy.checkPageHeading('#main-content > div:nth-child(2) > div.govuk-grid-column-three-quarters > table:nth-child(4) > thead > tr > th:nth-child(2)', expectedTableHeaders[1]);
+
+
+        // And the week 1 searches result exists
+        cy.get('[data-testid="searches-week1"]').should('exist');
+
+        // And the week 2 searches result exists
+        cy.get('[data-testid="searches-week2"]').should('exist');
+
+        // And the week 3 searches result exists
+        cy.get('[data-testid="searches-week3"]').should('exist');
+
+        // And the week 4 searches result exists
+        cy.get('[data-testid="searches-week4"]').should('exist');
+        
+        // And the 4 week searches result is displayed
+        cy.checkElementContainsText('[data-testid="searches-total"]', expected4WeeksReportMetric);
 
     })
+
+
 });

--- a/cypress/e2e/laManager/manageServices/editService-laMan-furtherInformation.spec.js
+++ b/cypress/e2e/laManager/manageServices/editService-laMan-furtherInformation.spec.js
@@ -5,7 +5,7 @@ const expectedPageUrl = "https://test.manage-family-support-services-and-account
 
 describe('LA Man - manage services - edit further information', () => {
     beforeEach(() => {
-        // Given I am logged in as DFE admin
+        // Given I am logged in as LA admin
         cy.visit('/')
         cy.integrationLogin('laman')
 

--- a/cypress/e2e/laManager/manageServices/editService-laMan-serviceDetails.spec.js
+++ b/cypress/e2e/laManager/manageServices/editService-laMan-serviceDetails.spec.js
@@ -7,7 +7,7 @@ const expectedPageUrl = "https://test.manage-family-support-services-and-account
 
 describe('LA Man - manage services - edit service details', () => {
     beforeEach(() => {
-        // Given I am logged in as DFE admin
+        // Given I am logged in as LA admin
         cy.visit('/')
         cy.integrationLogin('laman')
 

--- a/cypress/e2e/laManager/manageServices/navigationViewService-laMan.spec.js
+++ b/cypress/e2e/laManager/manageServices/navigationViewService-laMan.spec.js
@@ -1,6 +1,6 @@
 describe('LA Man - manage services - navigate to view service page', () => {
     beforeEach(() => {
-        // Given I am logged in as DFE admin
+        // Given I am logged in as LA admin
         cy.visit('/')
         cy.integrationLogin('laman')
         // And I click the manage services link

--- a/cypress/e2e/laManager/manageServices/viewService-laMan.spec.js
+++ b/cypress/e2e/laManager/manageServices/viewService-laMan.spec.js
@@ -1,6 +1,6 @@
 describe('LA Man - manage services - view services list', () => {
     beforeEach(() => {
-        // Given I am logged in as DFE admin
+        // Given I am logged in as LA admin
         cy.visit('/')
         cy.integrationLogin('laman')
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -296,6 +296,14 @@ Cypress.Commands.add('checkPageHeading', (locator, expectedHeading) => {
     })
 })
 
+// check element contains test
+Cypress.Commands.add('checkElementContainsText', (locator, expectedHeading) => {
+  cy.get(locator).should('be.visible').invoke('text').then((text) => {
+      const trimmedText = text.trim();
+      expect(trimmedText).to.contains(expectedHeading);
+  })
+})
+
 // check static text using locator
 Cypress.Commands.add('getTextOfElements', (locator, actualList, expectedList) => {
     cy.get(locator).each(($element) => {

--- a/cypress/support/navigationCommands.js
+++ b/cypress/support/navigationCommands.js
@@ -7,3 +7,13 @@ Cypress.Commands.add('navigateToViewServicesPage',()=>{
 Cypress.Commands.add('navigateToDfeAdminViewServicesPage',()=>{
     cy.visit('/manage-services?servicetype=La')
  })
+ 
+ // Navigate to Find Reports Page
+ Cypress.Commands.add('navigateToViewFindReportsPage',()=>{
+    cy.visit('/performance-data/Find')
+ })
+
+// Navigate to Connect Reports Page
+Cypress.Commands.add('navigateToViewConnectReportsPage',()=>{
+    cy.visit('/performance-data/Connect')
+ })


### PR DESCRIPTION
### Jira link

https://dfedigital.atlassian.net/browse/FHG-5269

### What?

I have added a new folder for kpi tests in la admin.
2 new test files with tests covering the navigation to the kpi report pages and verify data on the find report for a la admin.

### Why?

I am doing this because we need to ensure kpi reports are displayed as expected. Note: we are not asserting on values shown due to test data constantly changing. To be resolved once system test integration env set up.


### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

Test pass in test env 

<img width="341" alt="image" src="https://github.com/DFE-Digital/fh-admin-service-testing/assets/162156644/1b3a69ae-fa21-41a5-aed0-59469bda1e8a">
<img width="341" alt="image" src="https://github.com/DFE-Digital/fh-admin-service-testing/assets/162156644/1b3a69ae-fa21-41a5-aed0-59469bda1e8a">



