### PR TITLE
FHG-5451_UI_Test_For_Connection_request_accepted_For_Connect_Performance_Metrics

### DIFF
--- a/cypress/e2e/dfeAdmin/kpiReports/viewConnectReport-dfeAdmin-performanceData.spec.js
+++ b/cypress/e2e/dfeAdmin/kpiReports/viewConnectReport-dfeAdmin-performanceData.spec.js
@@ -38,6 +38,7 @@ describe("DfE Admin - KPI report for Connect", () => {
         let expectedTableHeaders = ["Measure", "Number"];
         const expectedSearchesReportMetric =  "Searches";
         const expectedConnectionRequestsReportMetric =  "Connection requests sent";
+        const expectedConnectionRequestsAcceptedReportMetric =  "Connection requests accepted";
 
         // Then the page heading for the Connect report is displayed correctly
         cy.checkPageHeading('[data-testid="h2-overall"]', expectedSubHeading);
@@ -49,6 +50,7 @@ describe("DfE Admin - KPI report for Connect", () => {
         // And the searches and connection request metrics are displayed
         cy.checkElementContainsText('[data-testid="overall-searches"]', expectedSearchesReportMetric);
         cy.checkElementContainsText('[data-testid="overall-requests-sent"]', expectedConnectionRequestsReportMetric);
+        cy.checkElementContainsText('[data-testid="overall-requests-accepted"]', expectedConnectionRequestsAcceptedReportMetric);
     })
 
     it('user can view number of searches and connections requests for an LA in past 7 days', () => {
@@ -56,6 +58,7 @@ describe("DfE Admin - KPI report for Connect", () => {
         let expectedTableHeaders = ["Measure", "Number"];
         const expectedSearchesReportMetric =  "Searches";
         const expectedConnectionRequestsReportMetric =  "Connection requests sent";
+        const expectedConnectionRequestsAcceptedReportMetric =  "Connection requests accepted";
 
         // Then the page heading for the Connect report is displayed correctly
         cy.checkPageHeading('[data-testid="h2-daily"]', expectedSubHeading);
@@ -67,12 +70,12 @@ describe("DfE Admin - KPI report for Connect", () => {
         // And the past 7 days searches and connection requests metrics are displayed
         cy.checkElementContainsText('[data-testid="recent-searches"]', expectedSearchesReportMetric);
         cy.checkElementContainsText('[data-testid="recent-requests-sent"]', expectedConnectionRequestsReportMetric);
-
+        cy.checkElementContainsText('[data-testid="recent-requests-accepted"]', expectedConnectionRequestsAcceptedReportMetric);
     })
 
     it('user can view number of searches and connections requests for an LA in the past 4 weeks', () => {
         const expectedSubHeading = "Searches and connection requests in the last 4 weeks";
-        let expectedTableHeaders = ["Week", "Number of searches", "Connection requests sent"];
+        let expectedTableHeaders = ["Week", "Number of searches", "Connection requests sent", "Connection requests accepted"];
         const expected4WeeksReportMetric =  "Total";
 
         // Then the page heading for the Connect report is displayed correctly
@@ -82,6 +85,7 @@ describe("DfE Admin - KPI report for Connect", () => {
         cy.checkPageHeading('[data-testid="th-week-weekly"]', expectedTableHeaders[0]);
         cy.checkPageHeading('[data-testid="th-number-of-searches-weekly"]', expectedTableHeaders[1]);
         cy.checkPageHeading('[data-testid="th-number-of-requests-made-weekly"]', expectedTableHeaders[2]);
+        cy.checkPageHeading('[data-testid="th-number-of-requests-accepted-weekly"]', expectedTableHeaders[3]);
 
 
         // And the week 1 searches result exists


### PR DESCRIPTION
FHG-5451_Added Tests For Connection request accepted for Connect Performance Metrics

### Jira link
https://dfedigital.atlassian.net.mcas.ms/browse/FHG-5615


[### What?]

I have Updated Testcase :viewConnectReport-dfeAdmin-performanceData.spec


I am doing this because:
to ensure connection accepted entries have test coverage in the UI suite of tests 


![Screenshot 2024-07-19 at 10 28 29](https://github.com/user-attachments/assets/81163206-b612-49d8-ac3e-2b4f5d5457c6)

